### PR TITLE
build: remove rust-overlay from flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,28 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768963622,
-        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,17 @@
   description = "Custom Personal Packages";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
-  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  # inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  # inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, rust-overlay }:
+  outputs = { self, nixpkgs }:
     let
       forAllSystems = f: nixpkgs.lib.genAttrs [ "x86_64-linux" ] (system:
         f {
           inherit system;
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [ rust-overlay.overlays.default ];
+            # overlays = [ rust-overlay.overlays.default ];
             config.allowUnfree = true;
           };
         }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -13,18 +13,18 @@ rec {
 
   # Zed Editor
   zed-editor = pkgs.callPackage ./zed-editor/default.nix {
-    rustPlatform = pkgs.makeRustPlatform {
-      cargo = pkgs.rust-bin.stable.latest.default;
-      rustc = pkgs.rust-bin.stable.latest.default;
-    };
+    # rustPlatform = pkgs.makeRustPlatform {
+    #   cargo = pkgs.rust-bin.stable.latest.default;
+    #   rustc = pkgs.rust-bin.stable.latest.default;
+    # };
   };
   zed-editor-fhs = zed-editor.fhs;
 
   zed-editor-preview = pkgs.callPackage ./zed-editor-preview/default.nix {
-    rustPlatform = pkgs.makeRustPlatform {
-      cargo = pkgs.rust-bin.stable.latest.default;
-      rustc = pkgs.rust-bin.stable.latest.default;
-    };
+    # rustPlatform = pkgs.makeRustPlatform {
+    #   cargo = pkgs.rust-bin.stable.latest.default;
+    #   rustc = pkgs.rust-bin.stable.latest.default;
+    # };
   };
   zed-editor-preview-fhs = zed-editor-preview.fhs;
 


### PR DESCRIPTION
Removes the rust-overlay input and its usage from flake.nix and flake.lock. Also comments out rustPlatform definitions in packages/default.nix.