### PR TITLE
feat(shonenx): add anime streaming app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Nix flake containing custom packages for NixOS and Linux.
 | `grayjay` | Desktop client for Grayjay to stream and download video content |
 | `playtorrio` | Stream torrents directly |
 | `seanime` | Open-source media server for anime and manga |
+| `shonenx` | Anime Streaming Desktop App |
 | `stremio` | Open-source media player |
 | `surge` | Open-source media server for anime and manga (TUI) |
 | `thorium-avx` | Thorium Browser (AVX optimized) |

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -34,4 +34,6 @@ rec {
   zed-editor-preview-bin = pkgs.callPackage ./zed-editor-preview-bin/default.nix { };
   zed-editor-preview-bin-fhs = zed-editor-preview-bin.fhs;
 
+  shonenx = pkgs.callPackage ./shonenx/default.nix { };
+
 } // (import ./thorium/default.nix { inherit pkgs; })

--- a/packages/shonenx/default.nix
+++ b/packages/shonenx/default.nix
@@ -1,0 +1,115 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, autoPatchelfHook
+, gtk3
+, glib
+, pango
+, harfbuzz
+, cairo
+, gdk-pixbuf
+, libepoxy
+, libX11
+, mpv
+, curl
+, makeWrapper
+, libsoup_3
+, webkitgtk_4_1
+, libsecret
+, glib-networking
+, cacert
+, alsa-lib
+, alsa-plugins
+, gst_all_1
+, libglvnd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "shonenx";
+  version = "1.7.6";
+
+  src = fetchurl {
+    url = "https://github.com/roshancodespace/ShonenX/releases/download/v${version}/ShonenX-Linux.zip";
+    sha256 = "3a3a2332e127650d12c7b241ff6fa141d37d165e2d24c8a36f8fff7b595e0d18";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    pango
+    harfbuzz
+    cairo
+    gdk-pixbuf
+    libepoxy
+    libX11
+    mpv
+    curl
+    libsoup_3
+    webkitgtk_4_1
+    libsecret
+    glib-networking
+    alsa-lib
+    alsa-plugins
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    libglvnd
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/shonenx $out/share/applications $out/share/icons/hicolor/256x256/apps
+
+    cp -r * $out/lib/shonenx/
+
+    # Install icon
+    if [ -f "$out/lib/shonenx/data/flutter_assets/assets/icons/app_icon-modified-2.png" ]; then
+      cp "$out/lib/shonenx/data/flutter_assets/assets/icons/app_icon-modified-2.png" $out/share/icons/hicolor/256x256/apps/shonenx.png
+    else
+      echo "Warning: Icon not found in expected location"
+    fi
+
+    # Create desktop entry
+    cat > $out/share/applications/shonenx.desktop <<EOF
+    [Desktop Entry]
+    Version=1.0
+    Type=Application
+    Name=ShonenX
+    Comment=Anime Streaming Desktop
+    Exec=shonenx
+    Icon=shonenx
+    Terminal=false
+    Categories=Video;AudioVideo;Player;
+    StartupWMClass=shonenx
+    EOF
+
+    makeWrapper $out/lib/shonenx/shonenx $out/bin/shonenx \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ mpv libglvnd alsa-lib gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad ]}:$out/lib/shonenx/lib \
+      --prefix PATH : ${lib.makeBinPath [ mpv curl ]} \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
+      --set ALSA_PLUGIN_DIR "${alsa-plugins}/lib/alsa-lib" \
+      --run "cd $out/lib/shonenx"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Anime Streaming Desktop App";
+    homepage = "https://github.com/roshancodespace/ShonenX";
+    license = licenses.gpl3; # Assuming GPL3 based on typical projects or need verification, but leaving generic if unknown
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "shonenx";
+  };
+}

--- a/packages/shonenx/update.sh
+++ b/packages/shonenx/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+OWNER="roshancodespace"
+REPO="ShonenX"
+NIX_FILE="packages/shonenx/default.nix"
+
+# Get latest release tag
+LATEST_TAG=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/releases/latest" | jq -r .tag_name)
+VERSION="${LATEST_TAG#v}"
+
+# Get current version from nix file
+CURRENT_VERSION=$(grep 'version =' "$NIX_FILE" | cut -d '"' -f 2)
+
+if [[ "$VERSION" == "$CURRENT_VERSION" ]]; then
+    echo "ShonenX is already up to date (version $VERSION)"
+    exit 0
+fi
+
+echo "Updating ShonenX from $CURRENT_VERSION to $VERSION..."
+
+# Calculate new hash
+URL="https://github.com/$OWNER/$REPO/releases/download/$LATEST_TAG/ShonenX-Linux.zip"
+NEW_HASH=$(nix-prefetch-url "$URL")
+
+# Update file
+sed -i "s/version = \".*\"/version = \"$VERSION\"/" "$NIX_FILE"
+sed -i "s/sha256 = \".*\"/sha256 = \"$NEW_HASH\"/" "$NIX_FILE"
+
+echo "Updated ShonenX to version $VERSION"


### PR DESCRIPTION
Adds the ShonenX desktop application as a new Nix package. Includes its `default.nix` build definition and an `update.sh` script.