### PR TITLE
Fix import path for seanime module in README, previous instruction causes infinite recursion on import.

### DIFF
--- a/packages/seanime/README.md
+++ b/packages/seanime/README.md
@@ -52,7 +52,7 @@ custom-packages.url = "github:rishabh5321/custom-packages-flake";
 ```nix
 { inputs, ... }: {
    imports = [
-     inputs.custom-packages.packages.${pkgs.stdenv.hostPlatform.system}.seanime
+     inputs.custom-packages.packages.nixosModules.seanime
    ];
 }
 ```


### PR DESCRIPTION
The current documentation instructs to import the Seanime module using inputs.custom-packages.packages.${pkgs.stdenv.hostPlatform.system}.seanime inside the imports array. Referencing pkgs inside top-level imports creates a circular dependency.