### PR TITLE
feat(altersend): add altersend package

### DIFF
--- a/packages/altersend/default.nix
+++ b/packages/altersend/default.nix
@@ -1,0 +1,34 @@
+{ appimageTools, fetchurl, lib }:
+let
+  pname = "altersend";
+  version = "1.3.0";
+  src = fetchurl {
+    name = "${pname}-${version}.AppImage";
+    url = "https://github.com/denislupookov/altersend/releases/download/v${version}/AlterSend-x86_64.AppImage";
+    hash = "sha256-kP5EZGyRQDy366nhCve8iBvC94UUv8QFc3tvNnBd/7Q=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname} || true
+    
+    install -m 444 -D ${appimageContents}/@altersenddesktop.desktop $out/share/applications/altersend.desktop
+    substituteInPlace $out/share/applications/altersend.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}' \
+      --replace-fail 'Icon=@altersenddesktop' 'Icon=${pname}'
+
+    install -m 444 -D ${appimageContents}/@altersenddesktop.png \
+      $out/share/icons/hicolor/1024x1024/apps/altersend.png
+  '';
+
+  meta = {
+    description = "A free, open-source, cross-platform application designed for private, peer-to-peer file transfers";
+    homepage = "https://github.com/denislupookov/altersend";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.asl20;
+    mainProgram = "altersend";
+  };
+}

--- a/packages/altersend/update.sh
+++ b/packages/altersend/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e
+
+# AlterSend Update Script
+
+CURRENT_VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' packages/altersend/default.nix || echo "0.0.0")
+echo "Current version: $CURRENT_VERSION"
+
+echo "Fetching releases from GitHub API..."
+RELEASES=$(gh api repos/denislupookov/altersend/releases)
+
+LATEST_TAG=$(echo "$RELEASES" | jq -r '[.[] | select(.prerelease == false and .draft == false)][0].tag_name')
+LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+
+if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" == "null" ]; then
+    echo "Could not extract valid release tag."
+    exit 1
+fi
+
+echo "Latest version: $LATEST_VERSION"
+
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+    echo "AlterSend is up-to-date."
+    echo "UPDATE_DETECTED=false" >> $GITHUB_ENV
+    exit 0
+fi
+
+echo "Update needed: $CURRENT_VERSION -> $LATEST_VERSION"
+echo "UPDATE_DETECTED=true" >> $GITHUB_ENV
+echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_ENV
+
+# Update version
+sed -i -E "s@(version\s*=\s*\")[^\"]+@\1${LATEST_VERSION}@" packages/altersend/default.nix
+
+# Calculate Hash
+DOWNLOAD_URL="https://github.com/denislupookov/altersend/releases/download/v${LATEST_VERSION}/AlterSend-x86_64.AppImage"
+echo "Download URL: $DOWNLOAD_URL"
+
+TEMP_FILE=$(mktemp)
+curl -sL "$DOWNLOAD_URL" -o "$TEMP_FILE"
+NEW_HASH=$(nix hash file "$TEMP_FILE")
+rm -f "$TEMP_FILE"
+
+if [ -z "$NEW_HASH" ]; then
+    echo "Failed to calculate hash."
+    exit 1
+fi
+
+echo "New Hash: $NEW_HASH"
+
+sed -i -E "s|(hash\s*=\s*\")[^\"]+(\";)|\1${NEW_HASH}\2|" packages/altersend/default.nix
+
+echo "AlterSend updated."

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -5,6 +5,7 @@ rec {
   better-control = pkgs.callPackage ./better-control/default.nix { };
   fladder = pkgs.callPackage ./fladder/default.nix { };
   antigravity = pkgs.callPackage ./antigravity/default.nix { };
+  altersend = pkgs.callPackage ./altersend/default.nix { };
   brave-origin = pkgs.callPackage ./brave-origin/default.nix { };
   anymex = pkgs.callPackage ./anymex/default.nix { };
   playtorrio = pkgs.callPackage ./playtorrio/default.nix { };


### PR DESCRIPTION
Introduces the AlterSend application as a Nix package.
Includes a Nix expression for packaging the AppImage and an update script to keep the version and hash current.
